### PR TITLE
fix: surface non-zero exit code for warnings

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -98,20 +98,12 @@ async function run() {
                     annotations
                 });
             }
-            if (exitCode === 2) {
-                await updateCheck(id, 'neutral', {
-                    title: checkName,
-                    summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,
-                });
-                process.exit(0);
-            } else {
-                console.log(`clj-kondo detects some problems. Please check founded problems at https://github.com/${GITHUB_REPOSITORY}/runs/${id}`);
-                await updateCheck(id, 'failure', {
-                    title: checkName,
-                    summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,
-                });
-                process.exit(78);
-            }
+            console.log(`clj-kondo detects some problems and exited with a non-zero code (${exitCode}). Please check founded problems at https://github.com/${GITHUB_REPOSITORY}/runs/${id}`);
+            await updateCheck(id, 'failure', {
+                title: checkName,
+                summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,
+            });
+            process.exit(78);
         } else if (exitCode == 0) {
             await updateCheck(id, 'success');
             process.exit(0);


### PR DESCRIPTION
Currently if clj-kondo detects warnings, it returns an exit code of `2`;
however, the `clojure-lint-action` script swallows the `2` and exits
with `0`. In this situation, it would be great to return a non-zero
exit code upstream so that the GH action reports a failure.

If consumers of the GH action only want the check to fail on errors,
they can provide the `--fail-level error` arg:

`clj-kondo --lint src --fail-level error`

Per https://github.com/clj-kondo/clj-kondo/blob/master/README.md#exit-codes, this returns
* a 0 if there are no warnings of errors
* a 0 if there are only warnings
* a 3 if there are errors