### PR TITLE
Fix: the clj-kondo Docker image has changed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM borkdude/clj-kondo:latest AS binary
+FROM cljkondo/clj-kondo:latest AS binary
 
 FROM node:10-slim
 


### PR DESCRIPTION
Hi, thanks a lot for creating this Github action. This PR updates the Docker image to the new clj-kondo Docker image.