### PR TITLE
Tweak summarize

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -98,7 +98,7 @@ async function run() {
                     annotations
                 });
             }
-            console.log(`clj-kondo detects some problems and exited with a non-zero code (${exitCode}). Please check founded problems at https://github.com/${GITHUB_REPOSITORY}/runs/${id}`);
+            console.log(`clj-kondo exited with a non-zero code (${exitCode}). Please find your report at https://github.com/${GITHUB_REPOSITORY}/runs/${id}`);
             await updateCheck(id, 'failure', {
                 title: checkName,
                 summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,

--- a/lib/run.js
+++ b/lib/run.js
@@ -75,6 +75,10 @@ const annotationLevels = {
     error: "failure"
 };
 
+function summarize({ duration, error, info, warning }) {
+  return `linting took ${duration}ms, errors: ${error}, warnings: ${warning}, info: ${info}`;
+}
+
 async function run() {
     const id = await createCheck();
     try {
@@ -94,14 +98,14 @@ async function run() {
                 }
                 await updateCheck(id, 'in-progress', {
                     title: checkName,
-                    summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,
+                    summary: summarize(stdout.summary),
                     annotations
                 });
             }
             console.log(`clj-kondo exited with a non-zero code (${exitCode}). Please find your report at https://github.com/${GITHUB_REPOSITORY}/runs/${id}`);
             await updateCheck(id, 'failure', {
                 title: checkName,
-                summary: `linting took ${stdout.summary.duration}ms, errors: ${stdout.summary.error}, warnings: ${stdout.summary.warning}, info: ${stdout.summary.info}`,
+                summary: summarize(stdout.summary),
             });
             process.exit(78);
         } else if (exitCode == 0) {


### PR DESCRIPTION
Hi Kirill,

Firstly, thanks for sharing the superb Clojure-orientated GitHub actions. They're much appreciated!

I noticed the output in a small reproduction I shared over in Clojurians used broken English and thought I'd share a subjective improvement for your consideration.

When in the code, I noticed some repeated logic, too, so added an additional commit that introduces a new function for summarising the linting process.

If I used the newer `const summarize => ()` syntax, I could eliminate the explicit `return` but noticed you're using the established `function` syntax, so stuck with that.

Thanks again for the awesome work!